### PR TITLE
Corrected vim error with clearing breakpoints

### DIFF
--- a/plugin/breakpoint.vim
+++ b/plugin/breakpoint.vim
@@ -47,7 +47,7 @@ function! s:WriteBreakpointsToFile()
 endfunction
 
 function! s:ClearBreakpoints()
-    s:BreakpointLocations = [ ]
+    let s:BreakpointLocations = [ ]
     call delete(g:breakpoint_script_file)
 endfunction
 


### PR DESCRIPTION
In function ClearBreakpoints it was spitting out errors when I'm clearing breakpoints